### PR TITLE
feat(server): add auth controllers, routes, and isAuthenticated midleware (#4)

### DIFF
--- a/server/package-lock.json
+++ b/server/package-lock.json
@@ -10,6 +10,9 @@
       "license": "MIT",
       "dependencies": {
         "@prisma/client": "^6.6.0",
+        "bcryptjs": "^3.0.2",
+        "cookie-parser": "^1.4.7",
+        "crypto": "^1.0.1",
         "dotenv": "^16.5.0",
         "express": "^5.1.0",
         "prisma": "^6.6.0"
@@ -505,6 +508,15 @@
         "node": ">= 0.6"
       }
     },
+    "node_modules/bcryptjs": {
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/bcryptjs/-/bcryptjs-3.0.2.tgz",
+      "integrity": "sha512-k38b3XOZKv60C4E2hVsXTolJWfkGRMbILBIe2IBITXciy5bOsTKot5kDrf3ZfufQtQOUN5mXceUEpU1rTl9Uog==",
+      "license": "BSD-3-Clause",
+      "bin": {
+        "bcrypt": "bin/bcrypt"
+      }
+    },
     "node_modules/body-parser": {
       "version": "2.2.0",
       "resolved": "https://registry.npmjs.org/body-parser/-/body-parser-2.2.0.tgz",
@@ -593,6 +605,25 @@
         "node": ">= 0.6"
       }
     },
+    "node_modules/cookie-parser": {
+      "version": "1.4.7",
+      "resolved": "https://registry.npmjs.org/cookie-parser/-/cookie-parser-1.4.7.tgz",
+      "integrity": "sha512-nGUvgXnotP3BsjiLX2ypbQnWoGUPIIfHQNZkkC668ntrzGWEZVW70HDEB1qnNGMicPje6EttlIgzo51YSwNQGw==",
+      "license": "MIT",
+      "dependencies": {
+        "cookie": "0.7.2",
+        "cookie-signature": "1.0.6"
+      },
+      "engines": {
+        "node": ">= 0.8.0"
+      }
+    },
+    "node_modules/cookie-parser/node_modules/cookie-signature": {
+      "version": "1.0.6",
+      "resolved": "https://registry.npmjs.org/cookie-signature/-/cookie-signature-1.0.6.tgz",
+      "integrity": "sha512-QADzlaHc8icV8I7vbaJXJwod9HWYp8uCqf1xa4OfNu1T7JVxQIrUgOWtHdNDtPiywmFbiS12VjotIXLrKM3orQ==",
+      "license": "MIT"
+    },
     "node_modules/cookie-signature": {
       "version": "1.2.2",
       "resolved": "https://registry.npmjs.org/cookie-signature/-/cookie-signature-1.2.2.tgz",
@@ -601,6 +632,13 @@
       "engines": {
         "node": ">=6.6.0"
       }
+    },
+    "node_modules/crypto": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/crypto/-/crypto-1.0.1.tgz",
+      "integrity": "sha512-VxBKmeNcqQdiUQUW2Tzq0t377b54N2bMtXO/qiLa+6eRRmmC4qT3D4OnTGoT/U6O9aklQ/jTwbOtRMTTY8G0Ig==",
+      "deprecated": "This package is no longer supported. It's now a built-in Node module. If you've depended on crypto, you should switch to the one that's built-in.",
+      "license": "ISC"
     },
     "node_modules/debug": {
       "version": "4.4.0",

--- a/server/package.json
+++ b/server/package.json
@@ -21,6 +21,9 @@
   "type": "module",
   "dependencies": {
     "@prisma/client": "^6.6.0",
+    "bcryptjs": "^3.0.2",
+    "cookie-parser": "^1.4.7",
+    "crypto": "^1.0.1",
     "dotenv": "^16.5.0",
     "express": "^5.1.0",
     "prisma": "^6.6.0"

--- a/server/src/controllers/auth.controller.js
+++ b/server/src/controllers/auth.controller.js
@@ -1,0 +1,181 @@
+import bcrypt from "bcryptjs";
+import { db } from "../utils/db.js";
+import { UserRole } from "../generated/prisma/index.js";
+import crypto from "crypto";
+import jwt from "jsonwebtoken";
+
+export const register = async (req, res) => {
+  const { email, password, name } = req.body;
+  if (!email || !password || !name) {
+    return res.status(400).json({ message: "All fields are required" });
+  }
+  try {
+    const userExists = await db.user.findUnique({ where: { email: email } });
+    if (userExists) {
+      return res.status(400).json({ message: "User already exists" });
+    }
+    const hashedPassword = await bcrypt.hash(password, 10);
+    const user = await db.user.create({
+      data: {
+        email: email,
+        password: hashedPassword,
+        name: name,
+        role: UserRole.USER,
+      },
+    });
+    if (!user) {
+      return res.status(400).json({
+        message: "User not created/registered",
+      });
+    }
+
+    return res.status(201).json({
+      message: "User registered successfully",
+      user: {
+        id: user.id,
+        email: user.email,
+        name: user.name,
+        role: user.role,
+        image: user?.image,
+      },
+    });
+  } catch (error) {
+    console.log("Registration Error: ", error);
+    return res.status(500).json({ error: error.message });
+  }
+};
+
+export const login = async (req, res) => {
+  const { email, password } = req.body;
+  if (!email || !password) {
+    return res.status(400).json({ message: "All fields are required" });
+  }
+  try {
+    const user = await db.user.findUnique({ where: { email: email } });
+    if (!user) {
+      return res.status(400).json({ message: "User not found" });
+    }
+
+    const isMatch = await bcrypt.compare(password, user.password);
+    if (!isMatch) {
+      return res.status(400).json({ message: "Invalid credentials" });
+    }
+
+    const accessToken = jwt.sign(
+      { id: user.id },
+      process.env.ACCESSTOKEN_SECRET,
+      {
+        expiresIn: process.env.ACCESSTOKEN_EXPIRY,
+      }
+    );
+    const refreshToken = jwt.sign(
+      { id: user.id },
+      process.env.REFRESHTOKEN_SECRET,
+      {
+        expiresIn: process.env.REFRESHTOKEN_EXPIRY,
+      }
+    );
+    
+    // Update refresh token in the database
+    await db.user.update({
+      where: { id: user.id },
+      data: { refreshToken: refreshToken },
+    });
+
+    const accessCookieOptions = {
+      httpOnly: true,
+      sameSite: "strict",
+      secure: process.env.NODE_ENV !== "development",
+      maxAge: 1 * 24 * 60 * 60 * 1000,
+    };
+
+    const refreshCookieOptions = {
+      httpOnly: true,
+      sameSite: "strict",
+      secure: process.env.NODE_ENV !== "development",
+      maxAge: 7 * 24 * 60 * 60 * 1000,
+    };
+
+    res.cookie("accessToken", accessToken, accessCookieOptions);
+    res.cookie("refreshToken", refreshToken, refreshCookieOptions);
+
+    res.status(200).json({
+      message: "Login successful",
+      user: {
+        id: user.id,
+        email: user.email,
+        name: user.name,
+        role: user.role,
+        image: user?.image,
+      },
+    });
+  } catch (error) {
+    console.error("Login Error:", error);
+    res.status(500).json({ error: "Login failed" });
+  }
+};
+
+
+export const logout = async (req, res) => {
+  try {
+    const userId = req.user.id;
+
+    await db.user.update({
+      where: { id: userId },
+      data: { refreshToken: null },
+    });
+
+    res.clearCookie("accessToken", {
+      httpOnly: true,
+      secure: process.env.NODE_ENV !== "development",
+      sameSite: "strict",
+    });
+
+    res.clearCookie("refreshToken", {
+      httpOnly: true,
+      secure: process.env.NODE_ENV !== "development",
+      sameSite: "strict",
+    });
+
+    res.status(200).json({
+      success: true,
+      message: "Logout successful",
+    });
+  } catch (error) {
+    console.error("Logout Error:", error);
+    res.status(500).json({ error: "Failed to log out" });
+  }
+};
+
+
+export const check = async (req, res) => {
+  try {
+    const user = await db.user.findUnique({
+      where: { id: req.user.id },
+    });
+
+    if (!user) {
+      return res.status(400).json({
+        success: false,
+        message: "User not found",
+      });
+    }
+
+    return res.status(200).json({
+      message: "Check successful",
+      user: {
+        id: user.id,
+        email: user.email,
+        name: user.name,
+        role: user.role,
+        image: user?.image,
+      },
+    });
+  } catch (error) {
+    console.error(error);
+    return res.status(400).json({
+      message: "Something went wrong",
+      success: false,
+    });
+  }
+};

--- a/server/src/index.js
+++ b/server/src/index.js
@@ -1,12 +1,17 @@
 import express from 'express'
 import dotenv from 'dotenv'
-
+import authRoutes from './routes/auth.routes.js'
+import cookieParser from 'cookie-parser'
 dotenv.config()
 const app = express()
+app.use(cookieParser());
+app.use(express.json())
 
 app.get('/', (req, res) => {
-    res.send('Hello World, this is the LeetLabs server!')
+    res.send('Hello World, this is the LeetLabs server!🔥')
 })
+
+app.use("/api/v1/auth", authRoutes)
 
 app.listen(process.env.PORT|| 3000, () => {
     console.log(`Server running on port ${process.env.PORT}`)   

--- a/server/src/middlewares/auth.middleware.js
+++ b/server/src/middlewares/auth.middleware.js
@@ -1,0 +1,148 @@
+import jwt from "jsonwebtoken";
+import { db } from "../utils/db.js";
+import cookieParser from "cookie-parser";
+export const isAuthenticated = async (req, res, next) => {
+  try {
+    const accessToken = req.cookies.accessToken;
+    const refreshToken = req.cookies.refreshToken;
+
+    if (!accessToken) {
+      if (!refreshToken) {
+        return res.status(401).json({
+          status: false,
+          message: "Unauthorized access",
+        });
+      } else {
+        const refreshDecoded = jwt.verify(
+          refreshToken,
+          process.env.REFRESHTOKEN_SECRET
+        );
+        console.log(refreshDecoded);
+
+        const user = await db.user.findUnique({
+          where: { id: refreshDecoded.id },
+          select: {
+            id: true,
+            image: true,
+            name: true,
+            email: true,
+            role: true,
+          },
+        });
+
+        if (!user) {
+          return res.status(401).json({
+            status: false,
+            message: "Unauthorized access",
+          });
+        }
+
+        const newAccessToken = jwt.sign(
+            { id: user.id },
+            process.env.ACCESSTOKEN_SECRET,
+            { expiresIn: process.env.ACCESSTOKEN_EXPIRY }
+          );
+          const newRefreshToken = jwt.sign(
+            { id: user.id },
+            process.env.REFRESHTOKEN_SECRET,
+            {
+              expiresIn: process.env.REFRESHTOKEN_EXPIRY,
+            }
+          );
+    
+          user.refreshToken = newRefreshToken;
+          await db.user.update({
+            where: { id: user.id },
+            data: { refreshToken: newRefreshToken },
+          });
+    
+          const accessCookieOptions = {
+            httpOnly: true,
+            sameSite: "strict",
+            secure: process.env.NODE_ENV !== "development",
+            maxAge: 1 * 24 * 60 * 60 * 1000,
+          };
+    
+          const refreshCookieOptions = {
+            httpOnly: true,
+            sameSite: "strict",
+            secure: process.env.NODE_ENV !== "development",
+            maxAge: 7 * 24 * 60 * 60 * 1000,
+          };
+    
+          // res.cookie("jwtToken", jwtToken, cookieOptions);
+          res.cookie("accessToken", newAccessToken, accessCookieOptions);
+          res.cookie("refreshToken", newRefreshToken, refreshCookieOptions);
+    
+          req.user = refreshDecoded;
+          next();
+      }
+    } else {
+      const accessDecoded = jwt.verify(
+        accessToken,
+        process.env.ACCESSTOKEN_SECRET
+      );
+
+      const user = await db.user.findUnique({
+        where: { id: accessDecoded.id },
+        select: {
+          id: true,
+          image: true,
+          name: true,
+          email: true,
+          role: true,
+        },
+      });
+      
+      if (!user) {
+        return res.status(401).json({
+          status: false,
+          message: "Unauthorized access",
+        });
+      }
+
+      const newAccessToken = jwt.sign(
+        { id: user.id },
+        process.env.ACCESSTOKEN_SECRET,
+        { expiresIn: process.env.ACCESSTOKEN_EXPIRY }
+      );
+      const newRefreshToken = jwt.sign(
+        { id: user.id },
+        process.env.REFRESHTOKEN_SECRET,
+        {
+          expiresIn: process.env.REFRESHTOKEN_EXPIRY,
+        }
+      );
+
+      user.refreshToken = newRefreshToken;
+      await db.user.update({
+        where: { id: user.id },
+        data: { refreshToken: newRefreshToken },
+      });
+
+      const accessCookieOptions = {
+        httpOnly: true,
+        sameSite: "strict",
+        secure: process.env.NODE_ENV !== "development",
+        maxAge: 1 * 24 * 60 * 60 * 1000,
+      };
+
+      const refreshCookieOptions = {
+        httpOnly: true,
+        sameSite: "strict",
+        secure: process.env.NODE_ENV !== "development",
+        maxAge: 7 * 24 * 60 * 60 * 1000,
+      };
+
+      // res.cookie("jwtToken", jwtToken, cookieOptions);
+      res.cookie("accessToken", newAccessToken, accessCookieOptions);
+      res.cookie("refreshToken", newRefreshToken, refreshCookieOptions);
+
+      req.user = accessDecoded;
+      next();
+    }
+  } catch (error) {
+    console.error("Error in isAuthenticated middleware:", error.message);
+    res.status(500).json({ message: "Internal Server Error" });
+  }
+};

--- a/server/src/routes/auth.routes.js
+++ b/server/src/routes/auth.routes.js
@@ -1,0 +1,10 @@
+import express from 'express';
+import { register, login, logout, check } from '../controllers/auth.controller.js';
+import { isAuthenticated } from '../middlewares/auth.middleware.js';
+const authRoutes = express.Router();
+
+authRoutes.post('/register', register);
+authRoutes.post('/login', login);
+authRoutes.post('/logout', isAuthenticated, logout);
+authRoutes.get('/check',isAuthenticated, check);
+export default authRoutes;

--- a/server/src/utils/db.js
+++ b/server/src/utils/db.js
@@ -1,4 +1,4 @@
-import {PrismaClient} from "../generated/prisma/client";
+import { PrismaClient } from '../generated/prisma/index.js';
 
 const globalForPrisma = globalThis;
 


### PR DESCRIPTION
## Summary
This PR implements basic authentication controllers and routes for user registration, login, logout, and checking if a user is logged in.  
It also introduces the `isAuthenticated` middleware to protect private routes by validating the access token.

## What's Added

-  **Register Controller** – For user registration.
-  **Login Controller** – For authenticating users and generating access + refresh tokens.
-  **Logout Controller** – For handling user logout.
-  **Check Controller** – For verifying if a user is logged in (using access token).
-  **isAuthenticated Middleware** – Middleware to validate access tokens and authorize users.
-  **JWT Token-based Authentication** setup (access token and refresh token management).

## Related Issue

Closes #4 ✅

## Notes

- Access tokens are used for short-term session (here 1 day) validation. 
- Refresh tokens are used to renew sessions without requiring login again (here 7 days).