### PR TITLE
feat(auth): add checkAdmin middleware to restrict access to admin-only routes (#16)

### DIFF
--- a/server/src/middlewares/auth.middleware.js
+++ b/server/src/middlewares/auth.middleware.js
@@ -146,3 +146,26 @@ export const isAuthenticated = async (req, res, next) => {
     res.status(500).json({ message: "Internal Server Error" });
   }
 };
+
+export const checkAdmin = async (req, res, next) => {
+  try {
+    const user = await db.user.findUnique({
+      where: { id: req.user.id },
+      select: {
+        role: true,
+      }
+    });
+
+    if (!user || user.role !== "admin") {
+      return res.status(401).json({
+        success: false,
+        message: "Access Denied! Admins Only Allowed",
+      });
+    }
+
+    next();
+  } catch (error) {
+    console.error("Error in checkAdmin middleware:", error.message);
+    res.status(500).json({ message: "Internal Server Error in checking admin role" });
+  }
+};


### PR DESCRIPTION
### Summary
Implement a middleware to restrict access to specific APIs only for users with the ADMIN role.

### Tasks
- Create checkAdmin middleware in `auth.middleware.js`
- Use role-based access control to validate if a user is an ADMIN
- Return proper error responses for unauthorized access attempts

### Changes
- Added `checkAdmin` middleware
- Updated authentication flow to support role checking

Closes #16