### PR TITLE
feat(server): add Problem model to Prisma schema and setup relation with User (#15)

### DIFF
--- a/server/prisma/migrations/20250428135313_create_problem_model/migration.sql
+++ b/server/prisma/migrations/20250428135313_create_problem_model/migration.sql
@@ -1,0 +1,26 @@
+-- CreateEnum
+CREATE TYPE "Difficulty" AS ENUM ('EASY', 'MEDIUM', 'HARD');
+
+-- CreateTable
+CREATE TABLE "Problem" (
+    "id" TEXT NOT NULL,
+    "title" TEXT NOT NULL,
+    "description" TEXT NOT NULL,
+    "difficulty" "Difficulty" NOT NULL,
+    "tags" TEXT[],
+    "userId" TEXT NOT NULL,
+    "examples" JSONB NOT NULL,
+    "constraints" TEXT NOT NULL,
+    "hints" TEXT,
+    "editorial" TEXT NOT NULL,
+    "testcases" JSONB NOT NULL,
+    "codeSnippets" JSONB NOT NULL,
+    "referenceSolutions" JSONB NOT NULL,
+    "createdAt" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    "updatedAt" TIMESTAMP(3) NOT NULL,
+
+    CONSTRAINT "Problem_pkey" PRIMARY KEY ("id")
+);
+
+-- AddForeignKey
+ALTER TABLE "Problem" ADD CONSTRAINT "Problem_userId_fkey" FOREIGN KEY ("userId") REFERENCES "User"("id") ON DELETE CASCADE ON UPDATE CASCADE;

--- a/server/prisma/schema.prisma
+++ b/server/prisma/schema.prisma
@@ -20,6 +20,12 @@ enum UserRole {
   CODER
 }
 
+enum Difficulty {
+  EASY
+  MEDIUM
+  HARD
+}
+
 model User {
   id String @id @default(uuid())
   name String?
@@ -36,4 +42,29 @@ model User {
   refreshTokenExpiry DateTime?
   createdAt DateTime @default(now())
   updatedAt DateTime @updatedAt
+
+  problems Problem[]
+}
+
+model Problem {
+  id String @id @default(uuid())
+  title String
+  description String
+  difficulty Difficulty
+  tags String[] //["tag1", "tag2", "tag3"]
+  userId String
+  examples Json
+  constraints String
+  hints String?
+  editorial String
+
+  testcases Json
+  codeSnippets Json
+  referenceSolutions Json
+
+  createdAt DateTime @default(now())
+  updatedAt DateTime @updatedAt
+
+  // Relationship
+  user User @relation(fields: [userId], references: [id], onDelete: Cascade)
 }


### PR DESCRIPTION
### Summary
Add a `Problem` model to the Prisma schema for managing coding problems.  
Set up a relation with the `User` model using `userId` as the foreign key.  
Ran `prisma generate` after updating the schema to apply changes.

---

### Tasks
- [x] Create Problem model in `schema.prisma`
- [x] Establish relation with User model (`userId`)
- [x] Run `prisma generate`
- [x] Prepare for future seeding and CRUD operations

---

### Linked Issue
Closes #15