### PR TITLE
fix: add missing base route for problem API's

### DIFF
--- a/server/src/index.js
+++ b/server/src/index.js
@@ -1,6 +1,7 @@
 import express from 'express'
 import dotenv from 'dotenv'
 import authRoutes from './routes/auth.routes.js'
+import problemRoutes from './routes/problem.routes.js'
 import cookieParser from 'cookie-parser'
 dotenv.config()
 const app = express()
@@ -12,6 +13,7 @@ app.get('/', (req, res) => {
 })
 
 app.use("/api/v1/auth", authRoutes)
+app.use("/api/v1/problems", problemRoutes)
 
 app.listen(process.env.PORT|| 3000, () => {
     console.log(`Server running on port ${process.env.PORT}`)   


### PR DESCRIPTION
This PR adds the missing base route for the problem-related APIs by including the line app.use("/api/v1/problems", problemRoutes) in the server configuration.